### PR TITLE
MarkerClusterGroup should be imported

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ EmberCLIEmberLeaflet.prototype.included = function included(app) {
       'ember-leaflet': 'default'
     }
   });
-  app.import('vendor/leaflet.markerclusterer/leaflet.markercluster.js', {
+  app.import('vendor/leaflet.markerclusterer/dist/leaflet.markercluster-src.js', {
     exports: {
       'L': 'default'
     }


### PR DESCRIPTION
If you include leaflet.markercluster in addon it should be imported.
